### PR TITLE
Prevent crash on 32 bit device when using arc4random

### DIFF
--- a/tun2socks/TSTCPSocket.swift
+++ b/tun2socks/TSTCPSocket.swift
@@ -89,12 +89,18 @@ struct SocketDict {
     }
     
     static func newKey() -> Int {
-        var key = arc4random()
-        while let _ = socketDict[Int(key)] {
-            key = arc4random()
+        var key = SocketDict.randomInt()
+        while let _ = socketDict[key] {
+            key = SocketDict.randomInt()
         }
         
-        return Int(key)
+        return key
+    }
+    
+    private static func randomInt() -> Int {
+        var r: Int = 0
+        arc4random_buf(&r, MemoryLayout<Int>.size)
+        return r
     }
 }
 


### PR DESCRIPTION
Using your fork has been great, but crashes for me on older device, this prevents that crash.